### PR TITLE
removes unused variable in code example in chapter 6

### DIFF
--- a/html/6_Complex_Data_Types.html
+++ b/html/6_Complex_Data_Types.html
@@ -715,7 +715,6 @@ number of input arguments, and their value:
 <pre class="src src-C"><span style="color: #483d8b;">#include</span> <span style="color: #8b2252;">&lt;stdio.h&gt;</span>
 
 <span style="color: #228b22;">int</span> <span style="color: #0000ff;">main</span>(<span style="color: #228b22;">int</span> <span style="color: #a0522d;">argc</span>, <span style="color: #228b22;">char</span>* <span style="color: #a0522d;">argv</span>[]) {
-  <span style="color: #228b22;">char</span>** <span style="color: #a0522d;">argp</span>;
   <span style="color: #228b22;">int</span> <span style="color: #a0522d;">i</span>;
   printf(<span style="color: #8b2252;">"argc = %d\n"</span>, argc);
   <span style="color: #a020f0;">for</span> (i=0; i&lt;argc; i++) {

--- a/org/6_Complex_Data_Types.org
+++ b/org/6_Complex_Data_Types.org
@@ -423,7 +423,6 @@ number of input arguments, and their value:
 #include <stdio.h>
     
 int main(int argc, char* argv[]) {
-  char** argp;
   int i;
   printf("argc = %d\n", argc);
   for (i=0; i<argc; i++) {


### PR DESCRIPTION
Small issue, but it seems the char*\* argp is unused and I assume can be safely removed.
